### PR TITLE
Fix a few issues, add "verbose" option

### DIFF
--- a/steamapi.py
+++ b/steamapi.py
@@ -5,6 +5,7 @@ def api_call_json(template, url_tokens):
     """Make a steam api call and return the json result, or throw a ValueError exception."""
     url = ("http://api.steampowered.com/" + template).format(**url_tokens)
     r = requests.get(url)
+    
     if r.status_code != 200:
         raise ValueError("Status code of request is not 200.")
     return r.json()


### PR DESCRIPTION
I reordered a few lines in `pick_random_achievement` to avoid a 403 when fetching achievements (if there's no achievements it crashed). I also added a "verbose" option that prints things like what the game id is, and the list of achievements ordered by completion percentage. These were always displayed before.